### PR TITLE
Update pubspec.yaml to flame 0.28.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: flame_geom
 description: Complement Flame with APIs for handling shapes and geometric operations.
-version: 0.2.4
+version: 0.2.5
 homepage: https://github.com/flame-engine/flame_geom
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  flame: ^0.26.0
+  flame: ^0.28.0
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Hi, this simple PR is solving dependency error

```
Because flame_geom >=0.2.4 depends on flame ^0.26.0 and ** depends on flame ^0.28.0, flame_geom >=0.2.4 is forbidden.
So, because littlegame depends on flame_geom 0.2.4, version solving failed.
pub get failed (1; So, because littlegame depends on flame_geom 0.2.4, version solving failed.)
Process finished with exit code 1
```
Thanks for eventual integration to master branch.

Best regard Ales.
